### PR TITLE
Release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project are documented in this file. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.0.4 (06-04-2025)
+* Limit to the peaks of density is set so it doesn't go negative anywhere
+
 ## 0.0.3 (05-27-2025)
 * Added magnetic filed strength and orientation as an output for IGRF library.
 * Added altitude as an optional input to the IGRF function.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 0.0.3
+cff-version: 0.0.4
 message: "If you use this software, please cite it as below."
 authors:
   - family-names: Forsythe
@@ -9,6 +9,6 @@ authors:
     given-names: Angeline G.
     orcid: https://orcid.org/0000-0001-8875-9326
     affiliation: U.S. Naval Research Laboratory
-title: victoriyaforsythe/PyIRI: v0.0.3
-version: v0.0.3
-date-released: 2025-05-27
+title: victoriyaforsythe/PyIRI: v0.0.4
+version: v0.0.4
+date-released: 2025-06-04

--- a/PyIRI/edp_update.py
+++ b/PyIRI/edp_update.py
@@ -387,7 +387,7 @@ def IRI_density_1day(year, mth, day, aUT, alon, alat, aalt, F107, coeff_dir,
     F1['fo'] = foF1
     F1['B_bot'] = B_F1_bot
 
-    # construct density
+    # Construct density
     EDP = reconstruct_density_from_parameters_1level(F2, F1, E, aalt)
 
     return F2, F1, E, Es, sun, mag, EDP

--- a/PyIRI/main_library.py
+++ b/PyIRI/main_library.py
@@ -3189,3 +3189,26 @@ def decimal_year(dtime):
     # year plus decimal
     date_decimal = dtime.year + decimal
     return date_decimal
+
+
+def limit_Nm(Nm):
+    """Replace negative density with 1e6.
+
+    Parameters
+    ----------
+    Nm : array-like
+        Electron density in m-3.
+
+    Returns
+    -------
+    Nm : array-like
+        Electron density in m-3 without negative values.
+
+    Notes
+    -----
+    This function replaces nans and negative density with 1e6.
+
+    """
+    Nm = np.nan_to_num(Nm)
+    Nm[Nm < 1e6] = 1e6
+    return Nm

--- a/docs/examples/ex_daily_parameters.rst
+++ b/docs/examples/ex_daily_parameters.rst
@@ -183,17 +183,6 @@ edp array:
 
 ::
 
-   plot.PyIRI_plot_M3000(f2, ahr, alon, alat, alon_2d, alat_2d, sun,
-   UT_plot, plot_dir, plot_name='PyIRI_M3000.png')
-
-
-.. image:: Figs/PyIRI_M3000_min_max.png
-    :width: 600px
-    :align: center
-    :alt: Global distribution of M3000.
-
-::
-
    plot.PyIRI_plot_hmF2(f2, ahr, alon, alat, alon_2d, alat_2d, sun,
    UT_plot, plot_dir, plot_name='PyIRI_hmF2.png')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PyIRI"
-version = "0.0.3"
+version = "0.0.4"
 description = "Python implementation of International Reference Ionosphere"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
# Description

Addresses #(issue)

Density went negative after extrapolation for very large F10.7.
A limit of 1e6 was introduced to fix this issue.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
locally


# Checklist:

- [ ] Make sure you are merging into the ``develop`` (not ``main``) branch
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
- [ ] Update zenodo.json file for new code contributors
