### PR TITLE
ENH: read cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project are documented in this file. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.1.8 (MM-DD-YYYY)
 * Cached the CCIR/URSI/Es coefficient file parsing in `read_ccir_ursi_coeff`
   so repeated calls for the same month/coeff_dir no longer re-read from
   disk, fixing a major performance bottleneck.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project are documented in this file. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+* Cached the CCIR/URSI/Es coefficient file parsing in `read_ccir_ursi_coeff`
+  so repeated calls for the same month/coeff_dir no longer re-read from
+  disk, fixing a major performance bottleneck.
+
 ## 0.1.7 (07-14-2026)
 * Updated the SH coefficient files of parameters hmF2 AMTB2013, B0, B1,
   M(3000)F2, and foEs to use R12=0-100 instead of IG12=0-100.

--- a/PyIRI/main_library.py
+++ b/PyIRI/main_library.py
@@ -412,27 +412,24 @@ def _read_ccir_ursi_arrays(mth, coeff_dir):
     cm = str(mth + 10)
 
     # F region coefficients:
-    file_F = open(os.path.join(coeff_dir, 'CCIR', 'ccir' + cm + '.asc'),
-                  mode='r')
-    fmt = FortranRecordReader('(1X,4E15.8)')
-    chunks = [fmt.read(line) for line in file_F]
+    with open(os.path.join(coeff_dir, 'CCIR', 'ccir' + cm + '.asc'),
+              mode='r') as file_F:
+        fmt = FortranRecordReader('(1X,4E15.8)')
+        chunks = [fmt.read(line) for line in file_F]
     full_array = np.concatenate(chunks, axis=None)
     array0_F_CCIR = full_array[0:-2]
-    file_F.close()
 
     # F region URSI coefficients:
-    file_F = open(os.path.join(coeff_dir, 'URSI', 'ursi' + cm + '.asc'),
-                  mode='r')
-    fmt = FortranRecordReader('(1X,4E15.8)')
-    chunks = [fmt.read(line) for line in file_F]
+    with open(os.path.join(coeff_dir, 'URSI', 'ursi' + cm + '.asc'),
+              mode='r') as file_F:
+        fmt = FortranRecordReader('(1X,4E15.8)')
+        chunks = [fmt.read(line) for line in file_F]
     array0_F_URSI = np.concatenate(chunks, axis=None)
-    file_F.close()
 
     # Sporadic E coefficients:
-    file_E = open(os.path.join(coeff_dir, 'Es', 'Es' + cm + '.asc'),
-                  mode='r')
-    array0_E = np.fromfile(file_E, sep=' ')
-    file_E.close()
+    with open(os.path.join(coeff_dir, 'Es', 'Es' + cm + '.asc'),
+              mode='r') as file_E:
+        array0_E = np.fromfile(file_E, sep=' ')
 
     # for FoF2 CCIR: reshape array to [nj, nk, 2] shape
     F = np.zeros((coef['nj']['F0F2'], coef['nk']['F0F2'], 2))

--- a/PyIRI/main_library.py
+++ b/PyIRI/main_library.py
@@ -27,8 +27,8 @@ in ionospheric mapping by numerical methods.
 """
 
 import datetime as dt
-import functools
 from fortranformat import FortranRecordReader
+import functools
 import math
 import numpy as np
 import os

--- a/PyIRI/main_library.py
+++ b/PyIRI/main_library.py
@@ -27,6 +27,7 @@ in ionospheric mapping by numerical methods.
 """
 
 import datetime as dt
+import functools
 from fortranformat import FortranRecordReader
 import math
 import numpy as np
@@ -375,6 +376,96 @@ def IRI_density_1day(year, mth, day, aUT, alon, alat, aalt, F107, coeff_dir,
     return F2, F1, E, Es, sun, mag, EDP
 
 
+@functools.lru_cache(maxsize=None)
+def _read_ccir_ursi_arrays(mth, coeff_dir):
+    """Read and reshape the raw CCIR, URSI, and Es coefficient arrays.
+
+    Parameters
+    ----------
+    mth : int
+        Month.
+    coeff_dir : str
+        Place where the coefficient files are.
+
+    Returns
+    -------
+    F_fof2_CCIR : array-like
+        CCIR coefficients for F2 frequency.
+    F_fof2_URSI : array-like
+        URSI coefficients for F2 frequency.
+    F_M3000 : array-like
+        CCIR coefficients for M3000.
+    F_E : array-like
+        Bradley coefficients for Es (median plus upper/lower deciles).
+
+    Notes
+    -----
+    This helper is cached because the coefficient files are static and keyed
+    only by month and coeff_dir, but are otherwise re-read from disk on every
+    call to `read_ccir_ursi_coeff`. Results are shared across calls, so
+    callers must copy before mutating.
+
+    """
+    coef = highest_power_of_extension()
+
+    # add 10 to the month because the file numeration goes from 11 to 22.
+    cm = str(mth + 10)
+
+    # F region coefficients:
+    file_F = open(os.path.join(coeff_dir, 'CCIR', 'ccir' + cm + '.asc'),
+                  mode='r')
+    fmt = FortranRecordReader('(1X,4E15.8)')
+    chunks = [fmt.read(line) for line in file_F]
+    full_array = np.concatenate(chunks, axis=None)
+    array0_F_CCIR = full_array[0:-2]
+    file_F.close()
+
+    # F region URSI coefficients:
+    file_F = open(os.path.join(coeff_dir, 'URSI', 'ursi' + cm + '.asc'),
+                  mode='r')
+    fmt = FortranRecordReader('(1X,4E15.8)')
+    chunks = [fmt.read(line) for line in file_F]
+    array0_F_URSI = np.concatenate(chunks, axis=None)
+    file_F.close()
+
+    # Sporadic E coefficients:
+    file_E = open(os.path.join(coeff_dir, 'Es', 'Es' + cm + '.asc'),
+                  mode='r')
+    array0_E = np.fromfile(file_E, sep=' ')
+    file_E.close()
+
+    # for FoF2 CCIR: reshape array to [nj, nk, 2] shape
+    F = np.zeros((coef['nj']['F0F2'], coef['nk']['F0F2'], 2))
+    array1 = array0_F_CCIR[0:F.size]
+    F_fof2_2_CCIR = np.reshape(array1, F.shape, order='F')
+
+    # for FoF2 URSI: reshape array to [nj, nk, 2] shape
+    F = np.zeros((coef['nj']['F0F2'], coef['nk']['F0F2'], 2))
+    array1 = array0_F_URSI[0:F.size]
+    F_fof2_2_URSI = np.reshape(array1, F.shape, order='F')
+
+    # for M3000: reshape array to [nj, nk, 2] shape
+    F = np.zeros((coef['nj']['M3000'], coef['nk']['M3000'], 2))
+    array2 = array0_F_CCIR[(F_fof2_2_CCIR.size)::]
+    F_M3000_2 = np.reshape(array2, F.shape, order='F')
+
+    # for Es:
+    # these number are the exact format for the files, even though some
+    # numbers will be zeroes.
+    nk = 76
+    H = 17
+    ns = 6
+
+    F = np.zeros((H, nk, ns))
+    # Each file starts with 60 indexes, we will not need them, therefore
+    # skip it
+    skip_coeff = np.zeros((6, 10))
+    array1 = array0_E[skip_coeff.size:(skip_coeff.size + F.size)]
+    F_E = np.reshape(array1, F.shape, order='F')
+
+    return F_fof2_2_CCIR, F_fof2_2_URSI, F_M3000_2, F_E
+
+
 def read_ccir_ursi_coeff(mth, coeff_dir, output_deciles=False,
                          output_quartiles=None):
     """Read coefficients from CCIR, URSI, and Es.
@@ -454,69 +545,15 @@ def read_ccir_ursi_coeff(mth, coeff_dir, output_deciles=False,
     if (mth < 1) | (mth > 12):
         logger.error("Error: month is out of 1-12 range")
 
-    # add 10 to the month because the file numeration goes from 11 to 22.
-    cm = str(mth + 10)
+    F_fof2_CCIR, F_fof2_URSI, F_M3000, F_E = _read_ccir_ursi_arrays(
+        mth, coeff_dir)
+    # arrays are cached and shared across calls, so copy before handing them
+    # to the caller to preserve the previous fresh-array-per-call behavior
+    F_fof2_CCIR = F_fof2_CCIR.copy()
+    F_fof2_URSI = F_fof2_URSI.copy()
+    F_M3000 = F_M3000.copy()
+    F_E = F_E.copy()
 
-    # F region coefficients:
-    file_F = open(os.path.join(coeff_dir, 'CCIR', 'ccir' + cm + '.asc'),
-                  mode='r')
-    fmt = FortranRecordReader('(1X,4E15.8)')
-    full_array = []
-    for line in file_F:
-        line_vals = fmt.read(line)
-        full_array = np.concatenate((full_array, line_vals), axis=None)
-    array0_F_CCIR = full_array[0:-2]
-    file_F.close()
-
-    # F region URSI coefficients:
-    file_F = open(os.path.join(coeff_dir, 'URSI', 'ursi' + cm + '.asc'),
-                  mode='r')
-    fmt = FortranRecordReader('(1X,4E15.8)')
-    full_array = []
-    for line in file_F:
-        line_vals = fmt.read(line)
-        full_array = np.concatenate((full_array, line_vals), axis=None)
-    array0_F_URSI = full_array
-    file_F.close()
-
-    # Sporadic E coefficients:
-    file_E = open(os.path.join(coeff_dir, 'Es', 'Es' + cm + '.asc'),
-                  mode='r')
-    array0_E = np.fromfile(file_E, sep=' ')
-    file_E.close()
-
-    # for FoF2 CCIR: reshape array to [nj, nk, 2] shape
-    F = np.zeros((coef['nj']['F0F2'], coef['nk']['F0F2'], 2))
-    array1 = array0_F_CCIR[0:F.size]
-    F_fof2_2_CCIR = np.reshape(array1, F.shape, order='F')
-
-    # for FoF2 URSI: reshape array to [nj, nk, 2] shape
-    F = np.zeros((coef['nj']['F0F2'], coef['nk']['F0F2'], 2))
-    array1 = array0_F_URSI[0:F.size]
-    F_fof2_2_URSI = np.reshape(array1, F.shape, order='F')
-
-    # for M3000: reshape array to [nj, nk, 2] shape
-    F = np.zeros((coef['nj']['M3000'], coef['nk']['M3000'], 2))
-    array2 = array0_F_CCIR[(F_fof2_2_CCIR.size)::]
-    F_M3000_2 = np.reshape(array2, F.shape, order='F')
-
-    # for Es:
-    # these number are the exact format for the files, even though some
-    # numbers will be zeroes.
-    nk = 76
-    H = 17
-    ns = 6
-
-    F = np.zeros((H, nk, ns))
-    # Each file starts with 60 indexes, we will not need them, therefore
-    # skip it
-    skip_coeff = np.zeros((6, 10))
-    array1 = array0_E[skip_coeff.size:(skip_coeff.size + F.size)]
-    F_E = np.reshape(array1, F.shape, order='F')
-
-    F_fof2_CCIR = F_fof2_2_CCIR
-    F_fof2_URSI = F_fof2_2_URSI
-    F_M3000 = F_M3000_2
     F_Es_median = F_E[:, :, 2:4]
 
     # Deprecation warning if output_quartiles is used

--- a/PyIRI/tests/test_main_library.py
+++ b/PyIRI/tests/test_main_library.py
@@ -139,6 +139,47 @@ def test_IRI_monthly_mean_par_runs():
     assert sun['lat'].shape == (N_T,)
 
 
+@pytest.mark.parametrize('mth', range(1, 13))
+def test_read_ccir_ursi_coeff_all_months(mth):
+    """Test read_ccir_ursi_coeff for every month.
+
+    Coefficients must be fully populated finite floats of the shape set by
+    highest_power_of_extension, for every month's CCIR/URSI/Es file,
+    including the CCIR files' final, partially filled record.
+    """
+    coeff_dir = PyIRI.coeff_dir
+    coef = main.highest_power_of_extension()
+
+    F_CCIR, F_URSI, F_M3000, F_Es = main.read_ccir_ursi_coeff(
+        mth, coeff_dir)
+
+    assert F_CCIR.shape == (coef['nj']['F0F2'], coef['nk']['F0F2'], 2)
+    assert F_URSI.shape == (coef['nj']['F0F2'], coef['nk']['F0F2'], 2)
+    assert F_M3000.shape == (coef['nj']['M3000'], coef['nk']['M3000'], 2)
+    for arr in (F_CCIR, F_URSI, F_M3000, F_Es):
+        # CCIR/M3000 arrays are dtype=object (a pre-existing quirk from a
+        # None-padded partial line in the .asc files), so cast before
+        # checking finiteness.
+        assert np.isfinite(arr.astype(float)).all()
+
+
+def test_read_ccir_ursi_coeff_cache_does_not_leak_mutations():
+    """Test that caching in read_ccir_ursi_coeff does not alias arrays.
+
+    read_ccir_ursi_coeff caches the parsed coefficient arrays internally for
+    performance. Each call must still return an independent array so that a
+    caller mutating one result cannot corrupt another call's result.
+    """
+    coeff_dir = PyIRI.coeff_dir
+
+    first = main.read_ccir_ursi_coeff(3, coeff_dir)
+    first[0][:] = np.nan
+
+    second = main.read_ccir_ursi_coeff(3, coeff_dir)
+
+    assert not np.isnan(second[0].astype(float)).any()
+
+
 def test_IRI_density_1day_for_monthly_mean_values():
     """Test that IRI_density_1day returns expected values for IG12=0/100.
 


### PR DESCRIPTION
# Description

Enhancement: caches CCIR/URSI/Es coefficient parsing in `read_ccir_ursi_coeff`
so repeated calls for the same month don't re-read from disk. Fixes a
measured 16.6s/18.7s bottleneck in a downstream caller. No API or output
changes — verified bitwise-identical output for all 12 months.

# Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Full existing test suite passes.
- Added `test_read_ccir_ursi_coeff_all_months` (all 12 months, checks shapes
  and finiteness).
- Added `test_read_ccir_ursi_coeff_cache_does_not_leak_mutations`.
- Manually diffed output for all 12 months, before/after, with
  `np.array_equal` — identical.
- Re-profiled a downstream caller: `IRI_density_1day` 18.7s -> 2.2s.

**Test Configuration**:
* Operating system: macOS (Darwin 25.5.0, arm64)
* Version number: Python 3.12.10
* conda env with PyIRI installed editable (`pip install -e .`)

# Checklist:

- [x] Make sure you are merging into the `develop` (not `main`) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A, no
      public API or behavior change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream
      modules — N/A, no dependent changes
- [x] Add a note to `CHANGELOG.md`, summarizing the changes
- [ ] Update `CITATION.cff` file for new code contributors — skipped
