### PR TITLE
Update numpy truncation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project are documented in this file. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.X.X (XX-XX-2026)
+* Replaced numpy `fix` with `trunc` to follow the new numpy standards
+
 ## 0.1.7 (07-14-2026)
 * Updated the SH coefficient files of parameters hmF2 AMTB2013, B0, B1,
   M(3000)F2, and foEs to use R12=0-100 instead of IG12=0-100.

--- a/PyIRI/main_library.py
+++ b/PyIRI/main_library.py
@@ -1128,8 +1128,8 @@ def solzen_timearray_grid(year, mth, day, T0, alon, alat):
     aslat = np.zeros((T0.size))
     for i in range(0, T0.size):
         UT = T0[i]
-        hour = np.fix(UT)
-        minute = np.fix((UT - hour) * 60.)
+        hour = np.trunc(UT)
+        minute = np.truc((UT - hour) * 60.0)
         date_sd = dt.datetime(int(year), int(mth), int(day),
                               int(hour), int(minute))
         jday = juldat(date_sd)
@@ -1908,7 +1908,7 @@ def set_temporal_array(dUT):
 
     """
     aUT = np.arange(0, 24, dUT)
-    ahour = np.fix(aUT).astype(int)
+    ahour = np.trunc(aUT).astype(int)
     aminute = ((aUT - ahour) * 60.).astype(int)
     asecond = (aUT * 0).astype(int)
     atime_frame_strings = [str(ahour[it]).zfill(2) + str(aminute[it]).zfill(2)

--- a/PyIRI/main_library.py
+++ b/PyIRI/main_library.py
@@ -1129,7 +1129,7 @@ def solzen_timearray_grid(year, mth, day, T0, alon, alat):
     for i in range(0, T0.size):
         UT = T0[i]
         hour = np.trunc(UT)
-        minute = np.truc((UT - hour) * 60.0)
+        minute = np.trunc((UT - hour) * 60.0)
         date_sd = dt.datetime(int(year), int(mth), int(day),
                               int(hour), int(minute))
         jday = juldat(date_sd)


### PR DESCRIPTION
# Description

Addresses #81 by replacing `np.fix` with `np.trunc`.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests, plus verified that the functions are the same:
```
import numpy as np

ut = 3.14159
np.fix(ut) == np.trunc(ut)
```

**Test Configuration**:
* Operating system: OS X Tahoe
* Version number: Python 3.10
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update ``CITATION.cff`` file for new code contributors
